### PR TITLE
Improvements

### DIFF
--- a/contract/assembly/index.ts
+++ b/contract/assembly/index.ts
@@ -1,8 +1,18 @@
-import { Coffee, set_beneficiary, get_beneficiary, set_coffee_price, get_coffee_price, add_coffee, get_coffee, total_coffees, STORAGE_COST } from "./model"
-import { ContractPromiseBatch, logging, context, u128 } from 'near-sdk-as';
+import {
+    add_coffee,
+    Coffee,
+    get_beneficiary,
+    get_coffee,
+    get_coffee_price,
+    set_beneficiary,
+    set_coffee_price,
+    STORAGE_COST,
+    total_coffees
+} from "./model"
+import {context, ContractPromiseBatch, logging, u128} from 'near-sdk-as';
 
 export function init(beneficiary: string, coffee_price: u128): void {
-    assert(context.predecessor == context.contractName, "Method new is private");
+    assert(context.predecessor == context.contractName, "Method is private");
     set_beneficiary(beneficiary);
     set_coffee_price(coffee_price);
 }
@@ -11,23 +21,22 @@ export function buyCoffee(coffee: Coffee): void {
     // check if amount attached is equal to the set fee
     const price = coffee_price();
     if (price.toString() != context.attachedDeposit.toString()) {
-        throw new Error("attached deposit should be equal to the pet's addoption fee")
+        throw new Error("attached deposit should be equal to the coffee price")
     }
+
+    // Send the money to the beneficiary
+    const beneficiary: string = get_beneficiary();
+    ContractPromiseBatch.create(beneficiary).transfer(u128.sub(price,STORAGE_COST));
 
     //Add coffee
     const coffee_number: i32 = add_coffee(Coffee.fromPayload(coffee));
 
     logging.log(`Thank you ${context.predecessor}! Coffee number: ${coffee_number}`)
-    // Send the money to the beneficiary
-    const beneficiary: string = get_beneficiary();
-    //@ts-ignore
-    ContractPromiseBatch.create(beneficiary).transfer(price - STORAGE_COST);
 }
 
-//Get adoption fee
+//Get coffee price
 export function coffee_price(): u128 {
-    const price: u128 = get_coffee_price();
-    return price;
+    return get_coffee_price();
 }
 
 // get a range of coffees

--- a/contract/assembly/model.ts
+++ b/contract/assembly/model.ts
@@ -6,6 +6,7 @@ export class Coffee {
     giver: string;
     name: string;
     message: string;
+    amount: u128;
     timestamp: u64;
     public static fromPayload(payload: Coffee): Coffee { //static method that takses a payload and returns a new Product object
         const coffee = new Coffee();
@@ -14,6 +15,7 @@ export class Coffee {
         coffee.name = payload.name;
         coffee.message = payload.message;
         coffee.timestamp = context.blockTimestamp;
+        coffee.amount = get_coffee_price();
         return coffee;
     }
 }

--- a/src/components/Coffee/Coffees.js
+++ b/src/components/Coffee/Coffees.js
@@ -27,7 +27,7 @@ const Coffees = () => {
         arr.push(coffees)
         setCoffees(arr)
       } else {
-        setCoffees(coffees)
+        setCoffees(coffees.reverse())
       }
       setCoffeePrice(await getCoffeePrice())
     } catch (error) {


### PR DESCRIPTION
## Improvements

- Added a `amount` attribute to the coffee model. That way even if the beneficiary changed the `coffee_price` after some time, we can still see the exact amount that someone donated in the past.
- Fixed the below error. You have to use u128.sub() method when subtracting 2 NEAR amounts. Because normal subtraction is not supported for u128 data type. https://github.com/OmoEsther/Buy-me-a-coffee-/blob/68fda8f1430832fc594c368d5eeac39801cf3aca/contract/assembly/index.ts#L24
- Changed the execution order of `buyCoffee` method in the smart contract. So that saving data to the blockchain is happening after the transfer is completed.
- Fixed some typos in smart contract comments
- Reversed the order of showing coffees. So that latest coffee is appearing in the top of the list. 